### PR TITLE
Remove pytest from published package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     ],
     packages=["sleeper_wrapper"],
     include_package_data=True,
-    install_requires=["requests>=2.22.0", "pytest==4.6.2"]
+    install_requires=["requests>=2.22.0"]
 )


### PR DESCRIPTION
Test/dev dependencies shouldn't be listed as install-requirements. This ties any project that uses this library to your outdated development version of pytest as well