### PR TITLE
Update README badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/SwapnikKatkoori/sleeper-api-wrapper.svg?branch=master)](https://travis-ci.org/SwapnikKatkoori/sleeper-api-wrapper)
-![GitHub](https://img.shields.io/github/license/SwapnikKatkoori/sleeper-api-wrapper.svg?color=blue)
-![GitHub issues](https://img.shields.io/github/issues/SwapnikKatkoori/sleeper-api-wrapper.svg?color=orange)
+![GitHub](https://img.shields.io/github/license/dtsong/sleeper-api-wrapper.svg?color=blue)
+![GitHub issues](https://img.shields.io/github/issues/dtsong/sleeper-api-wrapper.svg?color=orange)
 ![PyPI](https://img.shields.io/pypi/v/sleeper-api-wrapper)
 # sleeper-api-wrapper
 A Python API wrapper for Sleeper Fantasy Football, as well as tools to simplify data received. It makes all endpoints found in the sleeper api docs: https://docs.sleeper.app/ available and turns the JSON response received into Python types for easy usage.


### PR DESCRIPTION
I noticed the README badge links were still using the old repo so I moved them here. Removed the Travis CI badge - I don't think we have that running right now but LMK if I'm wrong!