### PR TITLE
Add docstrings for all non-Stats files

### DIFF
--- a/sleeper_wrapper/drafts.py
+++ b/sleeper_wrapper/drafts.py
@@ -3,18 +3,31 @@ from typing import Union
 from .base_api import BaseApi
 
 class Drafts(BaseApi):
+	"""The data associated with a given Sleeper draft.
+
+	Attributes:
+	  draft_id: Union[str, int]
+	    The Sleeper ID for the draft. May be provided as a string or int.
+	"""
+
 	def __init__(self, draft_id: Union[str, int]) -> None:
+		"""Initializes the instance based on draft ID.
+
+		Args:
+		  draft_id: Union[str, int]
+	        The Sleeper ID for the draft. May be provided as a string or int.
+		"""
 		self.draft_id = draft_id
 		self._base_url = "https://api.sleeper.app/v1/draft/{}".format(self.draft_id)
 
 	def get_specific_draft(self) -> dict:
-		"""gets the draft specified by the draft_id"""
+		"""Returns the draft's data."""
 		return self._call(self._base_url)
 
 	def get_all_picks(self) -> list:
-		"""gets all the picks in the draft specified by the draft_id"""
+		"""Returns all the picks in the specified draft."""
 		return self._call("{}/{}".format(self._base_url,"picks"))
 
 	def get_traded_picks(self) -> list:
-		"""gets all traded picks in the draft specified by the draft_id"""
+		"""Returns all the traded picks in the specified draft."""
 		return self._call("{}/{}".format(self._base_url,"traded_picks"))

--- a/sleeper_wrapper/league.py
+++ b/sleeper_wrapper/league.py
@@ -4,55 +4,97 @@ from .base_api import BaseApi
 from .stats import Stats
 
 class League(BaseApi):
+	"""The data associated with the given Sleeper league.
+
+	Can retrieve data for the league such as matchups, transactions, brackets,
+	drafts, scoreboards, and more. Some of these are simple calls to the 
+	Sleeper API while others add on a layer of data transformation or include
+	multiple calls.
+
+	Attributes:
+	  league_id: Union[str, int]
+	    The Sleeper ID for the league. May be provided as a string or int.
+	"""
+
 	def __init__(self, league_id: Union[str, int]) -> None:
+		"""Initializes the instance based on league ID.
+
+		Args:
+		  league_id: Union[str, int]
+		    Defines the league ID for data retrieval.
+		"""
 		self.league_id = league_id
 		self._base_url = "https://api.sleeper.app/v1/league/{}".format(self.league_id)
 		self._league = self._call(self._base_url)
 
 	def get_league(self) -> dict:
+		"""Returns the league data."""
 		return self._league
 
 	def get_rosters(self) -> list:
+		"""Retrieves the league's rosters."""
 		return self._call("{}/{}".format(self._base_url,"rosters"))
 
 	def get_users(self) -> list:
+		"""Retrieves the league's users."""
 		return self._call("{}/{}".format(self._base_url,"users"))
 
 	def get_matchups(self, week: Union[str, int]) -> list:
+		"""Retrieves the league's matchups for the given week."""
 		return self._call("{}/{}/{}".format(self._base_url,"matchups", week))
 
 	def get_playoff_winners_bracket(self) -> list:
+		"""Retrieves the winner's playoff bracket."""
 		return self._call("{}/{}".format(self._base_url,"winners_bracket"))
 
 	def get_playoff_losers_bracket(self) -> list:
+		"""Retrieves the loser's playoff bracket."""
 		return self._call("{}/{}".format(self._base_url,"losers_bracket"))
 
 	def get_transactions(self, week: Union[str, int]) -> list:
+		"""Retrieves all of a league's transactions for the given week."""
 		return self._call("{}/{}/{}".format(self._base_url,"transactions", week))
 
 	def get_trades(self, week: Union[str, int]) -> list:
+		"""Retrieves the league's trades for the given week."""
 		transactions = self.get_transactions(week)
 		return [t for t in transactions if t["type"] == "trade"]
 
 	def get_waivers(self, week: Union[str, int]) -> list:
+		"""Retrieves the league's waiver transactions for the given week."""
 		transactions = self.get_transactions(week)
 		return [t for t in transactions if t["type"] == "waiver"]
 
 	def get_free_agents(self, week: Union[str, int]) -> list:
+		"""Retrieves the league's free agent transactions for the given week."""
 		transactions = self.get_transactions(week)
 		return [t for t in transactions if t["type"] == "free_agent"]
 
 	def get_traded_picks(self) -> list:
+		"""Retrieves the league's traded draft picks."""
 		return self._call("{}/{}".format(self._base_url,"traded_picks"))
 
 	def get_all_drafts(self) -> list:
+		"""Retrieves all of a league's drafts.
+
+		This will typically return only one draft. 
+		"""
 		return self._call("{}/{}".format(self._base_url, "drafts"))
 
 	def map_users_to_team_name(self, users: list) -> dict:
-		"""returns dict {user_id:team_name}"""
-		users_dict = {}
+		"""Creates a mapping from user ID to team name.
+		
+		Args:
+		  users: list
+		    List of user IDs for the league.
 
-		#Maps the user_id to team name for easy lookup
+		Returns:
+		  A dict mapping the user ID to team name for each user / team
+		  combination in the league.
+		"""
+		users_dict = {}
+		
+		# Maps the user_id to team name for easy lookup
 		for user in users:
 			try:
 				users_dict[user["user_id"]] = user["metadata"]["team_name"]
@@ -61,7 +103,18 @@ class League(BaseApi):
 		return users_dict
 
 	def get_standings(self, rosters: list, users: list) -> dict:
-		"""returns list of tuples (team_name, wins, losses, points)"""
+		"""Creates standings based on the team's wins, losses, and ties.
+
+		Args:
+		  rosters: 
+		    List of rosters for the league.
+		  users: list
+		    List of user IDs for the league.
+
+		Returns:
+		  List of tuples (team_name, wins, losses, points) sorted by wins in
+		  descending order.
+		"""
 		users_dict = self.map_users_to_team_name(users)
 
 		roster_standings_list = []
@@ -85,7 +138,16 @@ class League(BaseApi):
 		return clean_standings_list
 
 	def map_rosterid_to_ownerid(self, rosters: list) -> dict:
-		"""returns dict {roster_id:[owner_id,pts]}"""
+		"""Creates a mapping from roster ID to owner ID.
+		
+		Args:
+		  rosters: list
+		    List of rosters for the league.
+
+		Returns:
+		  A dict mapping the roster ID to owner ID for each roster / owner
+		  combination in the league.
+		"""
 		result_dict = {}
 		for roster in rosters:
 			roster_id = roster["roster_id"]
@@ -95,16 +157,43 @@ class League(BaseApi):
 		return result_dict
 
 	def get_scoreboards(self, rosters: list, matchups: list, users: list, score_type: str, season: Union[str, int], week: Union[str, int]) -> Union[dict, None]:
-		"""returns dict {matchup_id:[(team_name,score), (team_name, score)]}"""
+		"""Returns the team names and scores from each matchup.
+
+		Uses the provided information about the league to create a scoreboard
+		for the given week. It pulls data from the rosters and users to find
+		the team name and then pulls the team's score. It does not currently
+		support leagues with custom scoring options and relies on the `Stats()`
+		class, which is no longer officially documented by Sleeper.
+
+		Args:
+		  rosters: list
+		    List of rosters for the league.
+		  matchups: list
+		    List of matchups for that week.
+		  users: list
+		    List of users for the league.
+		  score_type: str
+		    Scoring type for the league, eg "pts_std", "pts_ppr", or "pts_half_ppr"
+		  season: Union[str, int]
+		    The season to retrieve the scoreboards. May be provided as either a
+		    str or an int.
+		  week: Union[str, int]
+		    The week to retrieve the scoreboards. May be provided as either a
+		    str or an int.
+
+		Returns:
+		  A dict with the matchup ID as key and the corresponding teams' names
+		  and scores for that matchup.
+		"""
 		roster_id_dict = self.map_rosterid_to_ownerid(rosters)
 
 		if len(matchups) == 0:
 			return None
 
-		#Get the users to team name stats
+		# Get the users to team name stats
 		users_dict = self.map_users_to_team_name(users)
 
-		#map roster_id to points
+		# Map roster_id to points
 		scoreboards_dict = {}
 
 		for team in matchups:
@@ -128,7 +217,18 @@ class League(BaseApi):
 		return scoreboards_dict
 
 	def get_close_games(self, scoreboards: list, close_num: float) -> dict:
-		""" -Notes: Need to find a better way to compare scores rather than abs value of the difference of floats. """
+		"""Returns scoreboard's games where final margin is beneath given number.
+
+		Args:
+		  scoreboards: list
+		    List of scoreboards, which can be retrieved with the
+		    `get_scoreboards()` method.
+		  close_num: float
+		    The final margin to use as a threshold for determining close games.
+
+		Returns:
+		  A dict of matchups qualifying as close.
+		"""
 		close_games_dict = {}
 		for key in scoreboards:
 			team_one_score = scoreboards[key][0][1]
@@ -139,6 +239,30 @@ class League(BaseApi):
 		return close_games_dict
 
 	def get_team_score(self, starters: list, score_type: str, season: Union[str, int], week: Union[str, int]) -> float:
+		"""Retrieves a team's scores for a week based on the score type.
+
+		Uses the provided list of starters to pull their stats for that week
+		with the given score type. It does not currently support leagues with
+		custom scoring options because it pulls the pre-calculated score based
+		on score type and does not calculate the score based on the league's
+		scoring setting. It relies on the `Stats()` class to do this, which is 
+		no longer officially documented by Sleeper.
+
+		Args:
+		  starters: list
+		    A list of starters for the team.
+		  score_type: str
+		    Scoring type for the league, eg "pts_std", "pts_ppr", or "pts_half_ppr"
+		  season: Union[str, int]
+		    The season to retrieve the scores. May be provided as either a str 
+		    or an int.
+		  week: Union[str, int]
+		    The week to retrieve the scores. May be provided as either a str or
+		    an int.
+
+		Returns:
+		  The total score as a float for the team in that week.
+		"""
 		total_score = 0
 		stats = Stats()
 		week_stats = stats.get_week_stats("regular", season, week)
@@ -151,12 +275,19 @@ class League(BaseApi):
 
 		return total_score
 
-	def empty_roster_spots(self, user_id: str) -> Union[int, None]:
-		"""takes a user id and returns the number of empty roster spots on that team"""
-		# get league JSON
-		league = self.get_league()
+	def empty_roster_spots(self, user_id: Union[str, int]) -> Union[int, None]:
+		"""Returns the number of empty roster spots on a user's team.
+
+		Args:
+		  user_id: Union[str, int]
+		    The user's ID to check for empty roster spots.
+
+		Returns:
+		  The number of empty roster spots assuming the user was found. Otherwise
+		  returns `None`.
+		"""
 		# get size of maximum roster
-		max_roster_size = len(league["roster_positions"])
+		max_roster_size = len(self._league["roster_positions"])
 
 		# finds roster of user, returns max size - size of user roster
 		rosters = self.get_rosters()
@@ -169,8 +300,8 @@ class League(BaseApi):
 
 	
 	def get_league_name(self) -> str:
-		"""# returns name of league"""
-		return self.get_league()["name"]
+		"""Returns name of league."""
+		return self._league["name"]
 
 	def get_negative_scores(self, week: Union[str, int]) -> None:
 		pass

--- a/sleeper_wrapper/players.py
+++ b/sleeper_wrapper/players.py
@@ -1,11 +1,65 @@
-from .base_api import BaseApi 
+import logging
+
+from .base_api import BaseApi
+
+logging.basicConfig(level=logging.INFO)
 
 class Players(BaseApi):
+	"""Retrieves player data from Sleeper."""
+	
 	def __init__(self):
 		pass
 
-	def get_all_players(self):
+	def get_all_players(self, sport: str = "nfl") -> dict:
+		"""Gets all players from Sleeper.
+
+		Retrieves data pertaining to each player in the Sleeper, including
+		positions, biographical data, height / weight, team, and more.
+
+		Args:
+		  sport: str
+			The sport to retrieve the players. Options include "nfl",
+			"nba", and "lcs".
+
+		Returns:
+		  A dict of dicts where the keys are the player IDs and the values
+		  contain all of the player information.
+		"""
+
+		message = """Please use this call sparingly, as it is intended only to be used once per day at most to keep your player IDs updated.
+
+		Save the information to your own servers, if possible.
+		"""
+		logging.info(message)
 		return self._call("https://api.sleeper.app/v1/players/nfl")
 
-	def get_trending_players(self, sport: str, add_drop: str = "add", hours: int = 24, limit: int = 25):
+	def get_trending_players(self, sport: str, add_drop: str = "add", hours: int = 24, limit: int = 25) -> list:
+		"""Gets trending players from Sleeper.
+
+		Retrieves the player ID and number of adds / drops for that player
+		during the specified lookback hours.
+
+		Args:
+		  sport: str
+			The sport to retrieve the players. Options include "nfl",
+			"nba", and "lcs".
+		  add_drop: str
+		    Type of action to retreive. Either "add" or "drop".
+		  hours: int
+		    The number of hours to look back.
+		  limit: int
+		    The number of players to retrieve.
+
+		Returns:
+		  A list of dicts containing the player ID and a count of the adds /
+		  drops.
+		"""
+
+
+		message = """If you use this trending data, please attribute Sleeper.
+
+		Copy the code below to embed it in your app:
+		<iframe src="https://sleeper.app/embed/players/nfl/trending/add?lookback_hours=24&limit=25" width="350" height="500" allowtransparency="true" frameborder="0"></iframe>
+		"""
+		logging.info(message)
 		return self._call("https://api.sleeper.app/v1/players/{}/trending/{}?lookback_hours={}&limit={}".format(sport, add_drop, hours, limit))

--- a/sleeper_wrapper/user.py
+++ b/sleeper_wrapper/user.py
@@ -3,29 +3,66 @@ from typing import Union
 from .base_api import BaseApi
 
 class User(BaseApi):
+	"""The data associated with a given Sleeper user."""
+
 	def __init__(self, initial_user_input: Union[str, int]) -> None:
-		self.user_id = ""
+		"""Initializes the instance based on either username or user ID.
+
+		Args:
+		  initial_user_input: Union[str, int]
+		    The Sleeper user ID or username for the user. May be provided as a
+		    string or int.
+		"""
 		self._base_url = "https://api.sleeper.app/v1/user"
-		self._user = self._call("{}/{}".format(self._base_url,initial_user_input))
+		self._user = self._call("{}/{}".format(self._base_url, initial_user_input))
 		self._username = self._user["username"]
 		self._user_id = self._user["user_id"]
 
-	def get_user(self):
+	def get_user(self) -> dict:
+		"""Returns the user's data."""
 		return self._user
 
 	def get_all_leagues(self, sport: str, season: Union[str, int]) -> list:
+		"""Returns every league the user is in for that sport and season.
+
+		Args:
+		  sport: str
+		    The sport to retrieve the leagues. Options include "nfl",
+			"nba", and "lcs".
+		  season: Union[str, int]
+		    The season to retrieve the leagues. May be provided as either a
+		    str or an int.
+
+		Returns:
+		  A list of dicts corresponding to the leagues a user is in. Each entry
+		  will look akin to a specific League().get_league() call.
+		"""
 		return self._call("{}/{}/{}/{}/{}".format(self._base_url, self._user_id, "leagues", sport, season))
 
 	def get_all_drafts(self, sport: str, season: Union[str, int]) -> list:
-		return self._call("{}/{}/{}/{}/{}".format(self._base_url, self._user_id, "drafts",sport, season))
+		"""Returns every draft the user is in for that sport and season.
+
+		Args:
+		  sport: str
+		    The sport to retrieve the drafts. Options include "nfl",
+			"nba", and "lcs".
+		  season: Union[str, int]
+		    The season to retrieve the drafts. May be provided as either a
+		    str or an int.
+
+		Returns:
+		  A list of dicts corresponding to the drafts a user completed.
+		"""
+		return self._call("{}/{}/{}/{}/{}".format(self._base_url, self._user_id, "drafts", sport, season))
 
 	def get_username(self) -> str:
-		"""A method that might be useful to convert user_id to username. For example a user can initialize with a user_id and get a username"""
+		"""Retrieves username."""
 		return self._username
 
 	def get_user_id(self) -> str:
-		"""A method that might be useful to convert username to user_id. For example a user can initialize with a username and get a userid"""
+		"""Retrieves user_id."""
 		return self._user_id
 
 	def get_display_name(self) -> str:
+		"""Retrieves display name."""
 		return self._user["display_name"]


### PR DESCRIPTION
I added docstrings for all of the source files except `stats.py` since it has some functional changes waiting in PR #20 and I figured we could wait on that to make the changes. I tried to stay away from any functional changes in these files as I wanted this PR to be purely aesthetic, though I definitely found some spots that I'd like to clean up in future PRs. Once again the branch is pulled from and compared to the `add_type_hints` one since that's where this work started.

I used [Google style](https://google.github.io/styleguide/pyguide.html) for the docstrings, though I added type annotations to them.

I did add some logging messages to the `players.py` file to match what Sleeper has in their documentation, too. 