### PR TITLE
Fix the naming in the pyproject file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 
 [tool.poetry]
 name = "sleeper-api-wrapper"
+packages = [ { include = "sleeper_wrapper" } ]
 version = "1.1.0"
 description = "A Python API wrapper for Sleeper Fantasy sports, as well as tools to simplify received data."
 authors = ["Dan Song, Ford Higgins <py-sleeper-api-wrapper-maintainers@googlegroups.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # pyproject.toml
 
 [tool.poetry]
-name = "sleeper-wrapper"
+name = "sleeper-api-wrapper"
 version = "1.1.0"
 description = "A Python API wrapper for Sleeper Fantasy sports, as well as tools to simplify received data."
 authors = ["Dan Song, Ford Higgins <py-sleeper-api-wrapper-maintainers@googlegroups.com>"]


### PR DESCRIPTION
Oops bungled the naming in the file. Missed the `api-`, so now there's a [different package on PyPI](https://pypi.org/project/sleeper-wrapper/) called just `sleeper-wrapper` instead of `sleeper-api-wrapper`. Guess I should've tried installing from Test PyPI after all and pushing to PyPI first before merging - wasn't sure about the best order of operations there. The more you know. Will have to figure out how to take the other one down.