### PR TITLE
Support get sport state endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Poetry
+poetry.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@
 
 ## Version 1.0.7
 - Fixed KeyError in the get_team_score() method.
+
+## Version 1.2.0
+- Added `get_sport_state` function to `league` module.

--- a/docs/league.md
+++ b/docs/league.md
@@ -1,13 +1,15 @@
 # League
+
+## League
 `sleeper_wrapper.League(league_id)`
 
 Instantiating a `League` object will allow interaction with Sleeper's [Leagues endpoint](https://docs.sleeper.com/#leagues) by pulling data for the league specified by the `league_id`. Examples for how the data is structured for methods hitting the API directly may be found in their documentation for the endpoint.
 
 
-## Attributes
+### Attributes
 `league_id` _(Union[int, str])_: The Sleeper ID for the league. May be provided as a string or int.
 
-## Methods
+### Methods
 `get_league()`: Returns the league's data.
 
 `get_rosters()`: Retrieves the league's rosters.
@@ -62,6 +64,11 @@ no longer officially documented by Sleeper.
 `get_league_name()`: Returns name of league.
 
 
+## Functions
+
+`get_sport_state()`: Returns current state for the given sport.
+
+
 ## Examples
 ```
 from sleeper_wrapper import League
@@ -79,4 +86,7 @@ standings = league.get_standings(rosters=rosters, users=users)
 
 # retrieves the scoreboard for the given week and returns it with user information
 scoreboards = league.get_scoreboards(rosters=rosters, matchups=matchups, users=users, score_type="pts_std", season=2023, week=1)
+
+# gets current NFL state, e.g. current week
+state = get_sport_state(sport="nfl")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ requests = "^2.22.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [tool.poetry]
 name = "sleeper-api-wrapper"
 packages = [ { include = "sleeper_wrapper" } ]
-version = "1.1.0"
+version = "1.2.0"
 description = "A Python API wrapper for Sleeper Fantasy sports, as well as tools to simplify received data."
 authors = ["Dan Song, Ford Higgins <py-sleeper-api-wrapper-maintainers@googlegroups.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
+pytest-mock = "*"

--- a/sleeper_wrapper/__init__.py
+++ b/sleeper_wrapper/__init__.py
@@ -1,4 +1,4 @@
-from .league import League
+from .league import get_sport_state, League
 from .base_api import BaseApi
 from .user import User
 from .drafts import Drafts

--- a/sleeper_wrapper/league.py
+++ b/sleeper_wrapper/league.py
@@ -308,3 +308,15 @@ class League(BaseApi):
 
 	def get_rosters_players(self) -> None:
 		pass
+
+
+def get_sport_state(sport: str = "nfl") -> dict:
+	"""
+	Returns info about the current state of the specified sport.
+
+	https://docs.sleeper.com/#get-nfl-state
+
+	Parameters:
+	  - sport: str: Options are "nfl", "nba", "lcs". Default "nfl".
+	"""
+	return BaseApi()._call("https://api.sleeper.app/v1/state/{}".format(sport))

--- a/tests/test_league.py
+++ b/tests/test_league.py
@@ -1,4 +1,4 @@
-from sleeper_wrapper import League 
+from sleeper_wrapper import get_sport_state, League 
 
 def test_get_league() -> None:
 	""" Tests the get_league method"""
@@ -165,3 +165,17 @@ def test_empty_roster_spots() -> None:
 
 def test_get_negative_scores() -> None:
 	pass
+
+def test_get_sport_state(mocker) -> None:
+	mock_data = {
+		"week": 1, 
+		"season_type": "regular"
+		}
+	mock_base_api_call = mocker.patch(
+		"sleeper_wrapper.league.BaseApi._call", return_value=mock_data
+		)
+	response = get_sport_state("nfl")
+	assert response == mock_data
+	mock_base_api_call.assert_called_once_with(
+		"https://api.sleeper.app/v1/state/nfl"
+		)

--- a/tests/test_league.py
+++ b/tests/test_league.py
@@ -125,7 +125,7 @@ def test_get_scoreboards() -> None:
 	matchups = league.get_matchups(1)
 	users = league.get_users()
 	rosters = league.get_rosters()
-	scoreboards = league.get_scoreboards(rosters, matchups, users, "pts_half_ppr", 1)
+	scoreboards = league.get_scoreboards(rosters, matchups, users, "pts_half_ppr", 2019, 1)
 	print(scoreboards)
 	assert isinstance(scoreboards, dict)
 
@@ -138,7 +138,7 @@ def test_get_close_games() -> None:
 	matchups = league.get_matchups(1)
 	users = league.get_users()
 	rosters = league.get_rosters()
-	scoreboards = league.get_scoreboards(rosters, matchups, users, "pts_half_ppr", 1)
+	scoreboards = league.get_scoreboards(rosters, matchups, users, "pts_half_ppr", 2019, 1)
 	close_games = league.get_close_games(scoreboards, 10)
 	assert isinstance(close_games, dict)
 

--- a/tests/test_league.py
+++ b/tests/test_league.py
@@ -157,7 +157,7 @@ def test_empty_roster_spots() -> None:
 	for user in users:
 		user_id = user["user_id"]
 		for roster in rosters:
-			if user_id == roster["user_id"]:
+			if user_id == roster["owner_id"]:
 				assert league.empty_roster_spots(user_id) is not None
 	
 	# Assertion 2

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -28,7 +28,7 @@ def test_get_player_week_score() -> None:
 
 
 	assert isinstance(score, dict)
-	assert score["pts_ppr"] == None
+	assert score["pts_ppr"] == 2.0
 
 	score = stats.get_player_week_score(week_stats, "1262")
 	assert isinstance(score, dict)
@@ -41,7 +41,7 @@ def test_get_player_week_score() -> None:
 
 	
 	score = stats.get_player_week_score(week_stats, "30000000000")
-	assert score is None
+	assert score == {}
 
 def test_get_player_week_stats() -> None:
 	stats = Stats()


### PR DESCRIPTION
Addresses #65 - adds a function to the `league` module to wrap the get sport state endpoint: https://docs.sleeper.com/#get-nfl-state

`get_sport_state` is not part of the `League` class as it doesn't follow the same API path and doesn't require a league ID to call. Open to changing this if anyone strongly thinks it should be a method attached to `League`.

### Changes:
- fix several previously failing tests
- add `get_sport_state` function to `league` module
- add unit test
- add `pytest` / `pytest-mock` to dev dependency group
